### PR TITLE
Replace JSON.stringify with toString

### DIFF
--- a/index.js
+++ b/index.js
@@ -247,8 +247,8 @@ function normalizeComparison(a,b) {
   }
 
   // Stringify for comparisons
-  a = JSON.stringify(a);
-  b = JSON.stringify(b);
+  a = a.toString();
+  b = b.toString();
 
   return [a,b];
 }


### PR DESCRIPTION
Using `JSON.stringify` to normalize values before comparison adds literal quotes to the values if they're already strings. I think it's more appropriate to just call `toString()` on the values themselves. The tests in #3 are currently failing but with this PR they all pass again.
