### PR TITLE
Fix date comparisons

### DIFF
--- a/lib/filters/where.js
+++ b/lib/filters/where.js
@@ -192,7 +192,7 @@ function normalizeComparison(a,b) {
 
   // If Comparing dates, keep them as dates
   if(_.isDate(a) && _.isDate(b)) {
-    return [a,b];
+    return [a.getTime(), b.getTime()];
   }
   // Otherwise convert them to ISO strings
   if (_.isDate(a)) { a = a.toISOString(); }
@@ -209,7 +209,7 @@ function normalizeComparison(a,b) {
 
   // If comparing date-like things, treat them like dates
   if (_.isString(a) && _.isString(b) && a.match(X_ISO_DATE) && b.match(X_ISO_DATE)) {
-    return ([new Date(a), new Date(b)]);
+    return ([new Date(a).getTime(), new Date(b).getTime()]);
   }
 
   return [a,b];

--- a/test/filterSpec.js
+++ b/test/filterSpec.js
@@ -54,6 +54,25 @@ describe('filter criteria', function() {
     }).results.length, 1);
   });
 
+  it('matches equal date', function() {
+    var values = [new Date(0), new Date(1), new Date(2)],
+      data = {
+        foo: []
+      };
+
+    for (var i = 0; i < values.length; i++) {
+      data.foo.push({
+        a: values[i]
+      });
+    }
+
+    assert.equal(wc('foo', data, {
+      where: {
+        a: new Date(1)
+      }
+    }).results.length, 1);
+  });
+
   it('matches not', function() {
     expectMatches(['not', '!'], [0, 1, 2], 1, 2);
   });


### PR DESCRIPTION
`==` operator returns true only if the dates on both sides of the operator refer to the same object.

``` js
var a = new Date(1);
var b = new Date(1);

console.log(a == a);  // true
console.log(a == b);  // false
console.log(a.getTime() == b.getTime());  // true
```
