### PR TITLE
Remove unused util function

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -31,18 +31,3 @@ module.exports = _.extend(
     // , rightJoin : require('./projections/rightJoin')
 
   });
-
-
-
-/**
- * Load CommonJS submodules from the specified
- * relative path.
- *
- * @return {Object}
- */
-function loadSubModules(relPath) {
-  return require('include-all')({
-    dirname: path.resolve(__dirname, relPath),
-    filter: /(.+)\.js$/
-  });
-}

--- a/package.json
+++ b/package.json
@@ -18,8 +18,7 @@
   "author": "Mike McNeil",
   "license": "MIT",
   "dependencies": {
-    "lodash": "~2.4.1",
-    "include-all": "~0.1.2"
+    "lodash": "~2.4.1"
   },
   "testDependencies": {
     "mocha": "~1.12.0",


### PR DESCRIPTION
Can we get rid of that function? I think it is unused and it cause problems in webpack due to expression in require() call.