### PR TITLE
Pass collection schema in

### DIFF
--- a/lib/filters/where.js
+++ b/lib/filters/where.js
@@ -14,10 +14,11 @@ var X_ISO_DATE = require('../X_ISO_DATE.constant');
  * @param  { Object }    where
  * @return { Object[] }
  */
-module.exports = function (data, where) {
+module.exports = function (data, where, schema) {
   if( !data ) return data;
+  schema = schema || {};
   return _.filter(data, function(tuple) {
-    return matchSet(tuple, where);
+    return matchSet(tuple, where, undefined, schema);
   });
 };
 
@@ -35,55 +36,54 @@ module.exports = function (data, where) {
 
 
 // Match a model against each criterion in a criteria query
-function matchSet(model, criteria, parentKey) {
-
+function matchSet(model, criteria, parentKey, schema) {
   // Null or {} WHERE query always matches everything
   if(!criteria || _.isEqual(criteria, {})) return true;
 
   // By default, treat entries as AND
   return _.all(criteria, function(criterion, key) {
-    return matchItem(model, key, criterion, parentKey);
+    return matchItem(model, key, criterion, parentKey, schema);
   });
 }
 
 
-function matchOr(model, disjuncts) {
+function matchOr(model, disjuncts, schema) {
   var outcomes = [];
   _.each(disjuncts, function(criteria) {
-    if(matchSet(model, criteria)) outcomes.push(true);
+    if(matchSet(model, criteria, undefined, schema)) outcomes.push(true);
   });
 
   var outcome = outcomes.length > 0 ? true : false;
   return outcome;
 }
 
-function matchAnd(model, conjuncts) {
+function matchAnd(model, conjuncts, schema) {
   var outcome = true;
   _.each(conjuncts, function(criteria) {
-    if(!matchSet(model, criteria)) outcome = false;
+    if(!matchSet(model, criteria, undefined, schema)) outcome = false;
   });
   return outcome;
 }
 
-function matchLike(model, criteria) {
+function matchLike(model, criteria, schema) {
   for(var key in criteria) {
     // Return false if no match is found
-    if (!checkLike(model[key], criteria[key])) return false;
+    if (!checkLike(model[key], criteria[key], schema)) return false;
   }
   return true;
 }
 
-function matchNot(model, criteria) {
-  return !matchSet(model, criteria);
+function matchNot(model, criteria, schema) {
+  return !matchSet(model, criteria, undefined, schema);
 }
 
-function matchItem(model, key, criterion, parentKey) {
+function matchItem(model, key, criterion, parentKey, schema) {
 
   // Handle special attr query
   if (parentKey) {
 
     if (key === 'equals' || key === '=' || key === 'equal') {
-      return matchLiteral(model,parentKey,criterion, compare['=']);
+      return matchLiteral(model, parentKey, criterion, compare['='], schema);
     }
     else if (key === 'not' || key === '!') {
 
@@ -100,34 +100,34 @@ function matchItem(model, key, criterion, parentKey) {
         return match ? false : true;
       }
 
-      return matchLiteral(model,parentKey,criterion, compare['!']);
+      return matchLiteral(model, parentKey, criterion, compare['!'], schema);
     }
     else if (key === 'greaterThan' || key === '>') {
-      return matchLiteral(model,parentKey,criterion, compare['>']);
+      return matchLiteral(model, parentKey, criterion, compare['>'], schema);
     }
     else if (key === 'greaterThanOrEqual' || key === '>=')  {
-      return matchLiteral(model,parentKey,criterion, compare['>=']);
+      return matchLiteral(model, parentKey, criterion, compare['>='], schema);
     }
     else if (key === 'lessThan' || key === '<')  {
-      return matchLiteral(model,parentKey,criterion, compare['<']);
+      return matchLiteral(model, parentKey, criterion, compare['<'], schema);
     }
     else if (key === 'lessThanOrEqual' || key === '<=')  {
-      return matchLiteral(model,parentKey,criterion, compare['<=']);
+      return matchLiteral(model, parentKey, criterion, compare['<='], schema);
     }
-    else if (key === 'startsWith') return matchLiteral(model,parentKey,criterion, checkStartsWith);
-    else if (key === 'endsWith') return matchLiteral(model,parentKey,criterion, checkEndsWith);
-    else if (key === 'contains') return matchLiteral(model,parentKey,criterion, checkContains);
-    else if (key === 'like') return matchLiteral(model,parentKey,criterion, checkLike);
+    else if (key === 'startsWith') return matchLiteral(model, parentKey, criterion, checkStartsWith, schema);
+    else if (key === 'endsWith') return matchLiteral(model, parentKey, criterion, checkEndsWith, schema);
+    else if (key === 'contains') return matchLiteral(model, parentKey, criterion, checkContains, schema);
+    else if (key === 'like') return matchLiteral(model, parentKey, criterion, checkLike, schema);
     else throw new Error ('Invalid query syntax!');
   }
   else if(key.toLowerCase() === 'or') {
-    return matchOr(model, criterion);
+    return matchOr(model, criterion, schema);
   } else if(key.toLowerCase() === 'not') {
-    return matchNot(model, criterion);
+    return matchNot(model, criterion, schema);
   } else if(key.toLowerCase() === 'and') {
-    return matchAnd(model, criterion);
+    return matchAnd(model, criterion, schema);
   } else if(key.toLowerCase() === 'like') {
-    return matchLike(model, criterion);
+    return matchLike(model, criterion, schema);
   }
   // IN query
   else if(_.isArray(criterion)) {
@@ -139,11 +139,11 @@ function matchItem(model, key, criterion, parentKey) {
   // Special attr query
   else if (_.isObject(criterion) && validSubAttrCriteria(criterion)) {
     // Attribute is being checked in a specific way
-    return matchSet(model, criterion, key);
+    return matchSet(model, criterion, key, schema);
   }
 
   // Otherwise, try a literal match
-  else return matchLiteral(model,key,criterion, compare['=']);
+  else return matchLiteral(model, key, criterion, compare['='], schema);
 
 }
 
@@ -239,9 +239,19 @@ function isNumbery (value) {
 }
 
 // matchFn => the function that will be run to check for a match between the two literals
-function matchLiteral(model, key, criterion, matchFn) {
-
+function matchLiteral(model, key, criterion, matchFn, schema) {
   var val = _.cloneDeep(model[key]);
+
+  if(schema && schema[key] && schema[key].type) {
+    var schemaType = schema[key].type;
+
+    // If the value in the schema is a Date, parse it into an ISO Date sting
+    // so that it can be compared.
+    if(schemaType === 'date') {
+      val = new Date(val).toISOString();
+      criterion = new Date(criterion).toISOString();
+    }
+  }
 
   // If the criterion are both parsable finite numbers, cast them
   if(isNumbery(criterion) && isNumbery(val)) {

--- a/lib/query.js
+++ b/lib/query.js
@@ -30,7 +30,7 @@ module.exports = function query ( /* classifier|tuples, data|criteria [, criteri
   // and expose it as part of our results.
   var INDEX_IN_ORIG_DATA = '.(ørigindex)';
 
-  var tuples, classifier, data, criteria;
+  var tuples, classifier, data, criteria, schema;
 
   // If no classifier is provided, and data was specified as an array
   // instead of an object, infer tuples from the array
@@ -48,6 +48,11 @@ module.exports = function query ( /* classifier|tuples, data|criteria [, criteri
     tuples = data[classifier];
   }
 
+  // If the schema was passed in, it will be the 4th argument (zero based)
+  if(arguments[3]) {
+    schema = arguments[3];
+  }
+
   // Clone tuples to avoid dirtying things up
   tuples = _.cloneDeep(tuples);
 
@@ -60,7 +65,7 @@ module.exports = function query ( /* classifier|tuples, data|criteria [, criteri
   criteria = criteria || {};
 
   // Query and return result set using criteria
-  tuples = _where(tuples, criteria.where);
+  tuples = _where(tuples, criteria.where, schema);
   tuples = _sort(tuples, criteria.sort);
   tuples = _skip(tuples, criteria.skip);
   tuples = _limit(tuples, criteria.limit);


### PR DESCRIPTION
This is a breaking change that passes the collection's schema into the criteria parser. This allows values to be cast when compared if `schema` is set to true.

Imagine the following example:

```javascript
{ where: { 'dob': { '>=': 'Sat Nov 09 2013 00:00:00 GMT-0600 (CST)' } } }
```

Normally that would fail but since we know `dob` is a date field, we can cast the value to a date when comparing the values.

This currently only works on dates but by passing the schema in it can be expanded to more types as the need comes up.